### PR TITLE
test: keeper governor funcs

### DIFF
--- a/tests/e2e/genesis.go
+++ b/tests/e2e/genesis.go
@@ -177,7 +177,6 @@ func modifyGenesis(path, moniker, amountStr string, addrAll []sdk.AccAddress, de
 
 	maxDepositPeriod := 10 * time.Minute
 	votingPeriod := 15 * time.Second
-	maxGovernors := uint64(100)
 	governorStatusChangePeriod := 30 * time.Second
 
 	govGenState := govv1.NewGenesisState(1,
@@ -189,7 +188,7 @@ func modifyGenesis(path, moniker, amountStr string, addrAll []sdk.AccAddress, de
 			sdk.ZeroDec().String(),
 			false, false, govv1.DefaultMinDepositRatio.String(),
 			govv1.DefaultQuorumTimeout, govv1.DefaultMaxVotingPeriodExtension, govv1.DefaultQuorumCheckCount,
-			maxGovernors, governorStatusChangePeriod, minGovernorSelfDelegation.String(),
+			governorStatusChangePeriod, minGovernorSelfDelegation.String(),
 		),
 	)
 	govGenState.Constitution = "This is a test constitution"

--- a/x/gov/keeper/delegation_test.go
+++ b/x/gov/keeper/delegation_test.go
@@ -1,0 +1,176 @@
+package keeper_test
+
+import (
+	"testing"
+
+	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
+	"github.com/stretchr/testify/assert"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestGovernanceDelegate(t *testing.T) {
+	assert := assert.New(t)
+	govKeeper, mocks, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
+	s := newFixture(t, ctx, 2, 3, 2, govKeeper, mocks)
+	// Setup the delegators
+	s.delegate(s.delAddrs[0], s.valAddrs[0], 1)
+	s.delegate(s.delAddrs[0], s.valAddrs[1], 2)
+	s.delegate(s.delAddrs[1], s.valAddrs[0], 5)
+	s.delegate(s.delAddrs[2], s.valAddrs[1], 8)
+
+	// Delegate to active governor
+	govKeeper.DelegateToGovernor(ctx, s.delAddrs[0], s.activeGovernors[0].GetAddress())
+	govKeeper.DelegateToGovernor(ctx, s.delAddrs[1], s.activeGovernors[0].GetAddress())
+	// Delegate to inactive governor
+	govKeeper.DelegateToGovernor(ctx, s.delAddrs[2], s.inactiveGovernor.GetAddress())
+
+	// Assert GetGovernanceDelegation
+	deleg1, found := govKeeper.GetGovernanceDelegation(ctx, s.delAddrs[0])
+	if assert.True(found, "deleg1 not found") {
+		assert.Equal(deleg1.DelegatorAddress, s.delAddrs[0].String())
+		assert.Equal(deleg1.GovernorAddress, s.activeGovernors[0].GovernorAddress)
+	}
+	deleg2, found := govKeeper.GetGovernanceDelegation(ctx, s.delAddrs[1])
+	if assert.True(found, "deleg2 not found") {
+		assert.Equal(deleg2.DelegatorAddress, s.delAddrs[1].String())
+		assert.Equal(deleg2.GovernorAddress, s.activeGovernors[0].GovernorAddress)
+	}
+	deleg3, found := govKeeper.GetGovernanceDelegation(ctx, s.delAddrs[2])
+	if assert.True(found, "deleg3 not found") {
+		assert.Equal(deleg3.DelegatorAddress, s.delAddrs[2].String())
+		assert.Equal(deleg3.GovernorAddress, s.inactiveGovernor.GovernorAddress)
+	}
+
+	// Assert IterateGovernorDelegations
+	var delegs []v1.GovernanceDelegation
+	govKeeper.IterateGovernorDelegations(ctx, s.activeGovernors[0].GetAddress(),
+		func(i int64, d v1.GovernanceDelegation) bool {
+			delegs = append(delegs, d)
+			return false
+		})
+	assert.ElementsMatch(delegs, []v1.GovernanceDelegation{deleg1, deleg2})
+	delegs = nil
+	govKeeper.IterateGovernorDelegations(ctx, s.inactiveGovernor.GetAddress(),
+		func(i int64, d v1.GovernanceDelegation) bool {
+			delegs = append(delegs, d)
+			return false
+		})
+	assert.ElementsMatch(delegs, []v1.GovernanceDelegation{deleg3})
+
+	// Assert GetAllGovernanceDelegationsByGovernor
+	allDelegs := govKeeper.GetAllGovernanceDelegationsByGovernor(ctx, s.activeGovernors[0].GetAddress())
+	assert.ElementsMatch(allDelegs, []*v1.GovernanceDelegation{&deleg1, &deleg2})
+	allDelegs = govKeeper.GetAllGovernanceDelegationsByGovernor(ctx, s.inactiveGovernor.GetAddress())
+	assert.ElementsMatch(allDelegs, []*v1.GovernanceDelegation{&deleg3})
+
+	// Assert GetGovernorValShares
+	valShare1, found := govKeeper.GetGovernorValShares(ctx, s.activeGovernors[0].GetAddress(), s.valAddrs[0])
+	if assert.True(found, "valShare1 not found") {
+		assert.Equal(valShare1, v1.GovernorValShares{
+			GovernorAddress:  s.activeGovernors[0].GovernorAddress,
+			ValidatorAddress: s.valAddrs[0].String(),
+			Shares:           sdk.NewDec(1 + 5),
+		})
+	}
+	valShare2, found := govKeeper.GetGovernorValShares(ctx, s.activeGovernors[0].GetAddress(), s.valAddrs[1])
+	if assert.True(found, "valShare2 not found") {
+		assert.Equal(valShare2, v1.GovernorValShares{
+			GovernorAddress:  s.activeGovernors[0].GovernorAddress,
+			ValidatorAddress: s.valAddrs[1].String(),
+			Shares:           sdk.NewDec(2),
+		})
+	}
+	_, found = govKeeper.GetGovernorValShares(ctx, s.inactiveGovernor.GetAddress(), s.valAddrs[0])
+	assert.False(found)
+	valShare3, found := govKeeper.GetGovernorValShares(ctx, s.inactiveGovernor.GetAddress(), s.valAddrs[1])
+	if assert.True(found, "valShare3 not found") {
+		assert.Equal(valShare3, v1.GovernorValShares{
+			GovernorAddress:  s.inactiveGovernor.GovernorAddress,
+			ValidatorAddress: s.valAddrs[1].String(),
+			Shares:           sdk.NewDec(8),
+		})
+	}
+
+	// Assert GetAllGovernorValShares
+	activeGovValShares := govKeeper.GetAllGovernorValShares(ctx, s.activeGovernors[0].GetAddress())
+	assert.ElementsMatch(activeGovValShares, []v1.GovernorValShares{valShare1, valShare2})
+	inactiveGovValShares := govKeeper.GetAllGovernorValShares(ctx, s.inactiveGovernor.GetAddress())
+	assert.ElementsMatch(inactiveGovValShares, []v1.GovernorValShares{valShare3})
+
+	// Assert IterateGovernorValShares
+	var valShares []v1.GovernorValShares
+	govKeeper.IterateGovernorValShares(ctx, s.activeGovernors[0].GetAddress(), func(i int64, v v1.GovernorValShares) bool {
+		valShares = append(valShares, v)
+		return false
+	})
+	assert.ElementsMatch(valShares, activeGovValShares)
+	valShares = nil
+	govKeeper.IterateGovernorValShares(ctx, s.inactiveGovernor.GetAddress(), func(i int64, v v1.GovernorValShares) bool {
+		valShares = append(valShares, v)
+		return false
+	})
+	assert.ElementsMatch(valShares, inactiveGovValShares)
+
+	// Assert RedelegateToGovernor
+	govKeeper.RedelegateToGovernor(ctx, s.delAddrs[0], s.inactiveGovernor.GetAddress())
+	allDelegs = govKeeper.GetAllGovernanceDelegationsByGovernor(ctx, s.activeGovernors[0].GetAddress())
+	assert.ElementsMatch(allDelegs, []*v1.GovernanceDelegation{&deleg2})
+	allDelegs = govKeeper.GetAllGovernanceDelegationsByGovernor(ctx, s.inactiveGovernor.GetAddress())
+	deleg1.GovernorAddress = s.inactiveGovernor.GovernorAddress
+	assert.ElementsMatch(allDelegs, []*v1.GovernanceDelegation{&deleg1, &deleg3})
+	valShare1, found = govKeeper.GetGovernorValShares(ctx, s.activeGovernors[0].GetAddress(), s.valAddrs[0])
+	if assert.True(found, "valShare1 not found") {
+		assert.Equal(valShare1, v1.GovernorValShares{
+			GovernorAddress:  s.activeGovernors[0].GovernorAddress,
+			ValidatorAddress: s.valAddrs[0].String(),
+			Shares:           sdk.NewDec(5),
+		})
+	}
+	_, found = govKeeper.GetGovernorValShares(ctx, s.activeGovernors[0].GetAddress(), s.valAddrs[1])
+	assert.False(found)
+	valShare2, found = govKeeper.GetGovernorValShares(ctx, s.inactiveGovernor.GetAddress(), s.valAddrs[0])
+	if assert.True(found, "valShare2 not found") {
+		assert.Equal(valShare2, v1.GovernorValShares{
+			GovernorAddress:  s.inactiveGovernor.GovernorAddress,
+			ValidatorAddress: s.valAddrs[0].String(),
+			Shares:           sdk.NewDec(1),
+		})
+	}
+	valShare3, found = govKeeper.GetGovernorValShares(ctx, s.inactiveGovernor.GetAddress(), s.valAddrs[1])
+	if assert.True(found, "valShare3 not found") {
+		assert.Equal(valShare3, v1.GovernorValShares{
+			GovernorAddress:  s.inactiveGovernor.GovernorAddress,
+			ValidatorAddress: s.valAddrs[1].String(),
+			Shares:           sdk.NewDec(10),
+		})
+	}
+
+	// Assert UndelegateFromGovernor
+	govKeeper.UndelegateFromGovernor(ctx, s.delAddrs[0])
+	allDelegs = govKeeper.GetAllGovernanceDelegationsByGovernor(ctx, s.activeGovernors[0].GetAddress())
+	assert.ElementsMatch(allDelegs, []*v1.GovernanceDelegation{&deleg2})
+	allDelegs = govKeeper.GetAllGovernanceDelegationsByGovernor(ctx, s.inactiveGovernor.GetAddress())
+	deleg1.GovernorAddress = s.inactiveGovernor.GovernorAddress
+	assert.ElementsMatch(allDelegs, []*v1.GovernanceDelegation{&deleg3})
+	valShare1, found = govKeeper.GetGovernorValShares(ctx, s.activeGovernors[0].GetAddress(), s.valAddrs[0])
+	if assert.True(found, "valShare1 not found") {
+		assert.Equal(valShare1, v1.GovernorValShares{
+			GovernorAddress:  s.activeGovernors[0].GovernorAddress,
+			ValidatorAddress: s.valAddrs[0].String(),
+			Shares:           sdk.NewDec(5),
+		})
+	}
+	_, found = govKeeper.GetGovernorValShares(ctx, s.activeGovernors[0].GetAddress(), s.valAddrs[1])
+	assert.False(found)
+	_, found = govKeeper.GetGovernorValShares(ctx, s.inactiveGovernor.GetAddress(), s.valAddrs[0])
+	assert.False(found)
+	valShare3, found = govKeeper.GetGovernorValShares(ctx, s.inactiveGovernor.GetAddress(), s.valAddrs[1])
+	if assert.True(found, "valShare3 not found") {
+		assert.Equal(valShare3, v1.GovernorValShares{
+			GovernorAddress:  s.inactiveGovernor.GovernorAddress,
+			ValidatorAddress: s.valAddrs[1].String(),
+			Shares:           sdk.NewDec(8),
+		})
+	}
+}

--- a/x/gov/keeper/fixture_test.go
+++ b/x/gov/keeper/fixture_test.go
@@ -1,0 +1,170 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	sdkmath "cosmossdk.io/math"
+
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	"github.com/atomone-hub/atomone/x/gov/keeper"
+	"github.com/atomone-hub/atomone/x/gov/types"
+	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
+)
+
+type fixture struct {
+	t *testing.T
+
+	valAddrs    []sdk.ValAddress
+	delAddrs    []sdk.AccAddress
+	govAddrs    []types.GovernorAddress
+	totalBonded int64
+	validators  []stakingtypes.Validator
+	delegations []stakingtypes.Delegation
+
+	keeper *keeper.Keeper
+	ctx    sdk.Context
+	mocks  mocks
+
+	activeGovernors  []v1.Governor
+	inactiveGovernor v1.Governor
+	proposal         v1.Proposal
+}
+
+// newFixture returns a configured fixture for testing the govKeeper methods.
+// - track staking delegations and ensure the mock staking keeper replies
+// accordingly.
+// - setup 1 active and 1 inactive governors
+// - initiates the validators with a self delegation of 1:
+//   - setup IterateBondedValidatorsByPower call
+//   - setup IterateDelegations call for validators
+func newFixture(t *testing.T, ctx sdk.Context, numVals, numDelegators,
+	numGovernors int, govKeeper *keeper.Keeper, mocks mocks,
+) *fixture {
+	var (
+		addrs    = simtestutil.CreateRandomAccounts(numVals + numDelegators + numGovernors)
+		valAddrs = simtestutil.ConvertAddrsToValAddrs(addrs[:numVals])
+		delAddrs = addrs[numVals : numVals+numDelegators]
+		govAddrs = convertAddrsToGovAddrs(addrs[numVals+numDelegators:])
+		s        = &fixture{
+			t:        t,
+			ctx:      ctx,
+			valAddrs: valAddrs,
+			delAddrs: delAddrs,
+			govAddrs: govAddrs,
+			keeper:   govKeeper,
+			mocks:    mocks,
+		}
+	)
+	mocks.stakingKeeper.EXPECT().TotalBondedTokens(gomock.Any()).
+		DoAndReturn(func(_ context.Context) sdkmath.Int {
+			return sdkmath.NewInt(s.totalBonded)
+		}).MaxTimes(1)
+
+	// Mocks a bunch of validators
+	for i := 0; i < len(valAddrs); i++ {
+		s.validators = append(s.validators, stakingtypes.Validator{
+			OperatorAddress: valAddrs[i].String(),
+			Status:          stakingtypes.Bonded,
+			Tokens:          sdkmath.ZeroInt(),
+			DelegatorShares: sdkmath.LegacyZeroDec(),
+		})
+		// validator self delegation
+		s.delegate(sdk.AccAddress(valAddrs[i]), valAddrs[i], 1)
+	}
+	mocks.stakingKeeper.EXPECT().
+		IterateBondedValidatorsByPower(ctx, gomock.Any()).
+		DoAndReturn(
+			func(ctx context.Context, fn func(index int64, validator stakingtypes.ValidatorI) bool) error {
+				for i := 0; i < len(valAddrs); i++ {
+					fn(int64(i), s.validators[i])
+				}
+				return nil
+			}).AnyTimes()
+	mocks.stakingKeeper.EXPECT().
+		IterateDelegations(ctx, gomock.Any(), gomock.Any()).
+		DoAndReturn(
+			func(ctx context.Context, voter sdk.AccAddress, fn func(index int64, d stakingtypes.DelegationI) bool) error {
+				for i, d := range s.delegations {
+					if d.DelegatorAddress == voter.String() {
+						fn(int64(i), d)
+					}
+				}
+				return nil
+			}).AnyTimes()
+	mocks.stakingKeeper.EXPECT().GetValidator(ctx, gomock.Any()).DoAndReturn(
+		func(ctx context.Context, addr sdk.ValAddress) (stakingtypes.ValidatorI, bool) {
+			for i := 0; i < len(valAddrs); i++ {
+				if valAddrs[i].String() == addr.String() {
+					return s.validators[i], true
+				}
+			}
+			return nil, false
+		}).AnyTimes()
+	mocks.stakingKeeper.EXPECT().GetDelegation(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, del sdk.AccAddress, val sdk.ValAddress) (stakingtypes.Delegation, bool) {
+			for _, d := range s.delegations {
+				if d.DelegatorAddress == del.String() && d.ValidatorAddress == val.String() {
+					return d, true
+				}
+			}
+			return stakingtypes.Delegation{}, false
+		}).AnyTimes()
+
+	// Create active governors
+	for i := 0; i < len(govAddrs)-1; i++ {
+		governor, err := v1.NewGovernor(govAddrs[i].String(), v1.GovernorDescription{}, time.Now())
+		require.NoError(t, err)
+		govKeeper.SetGovernor(ctx, governor)
+		s.activeGovernors = append(s.activeGovernors, governor)
+	}
+	// Create one inactive governor
+	inactiveGovAddr := govAddrs[len(govAddrs)-1]
+	governor, err := v1.NewGovernor(inactiveGovAddr.String(), v1.GovernorDescription{}, time.Now())
+	require.NoError(t, err)
+	governor.Status = v1.Inactive
+	govKeeper.SetGovernor(ctx, governor)
+	s.inactiveGovernor = governor
+	return s
+}
+
+// delegate updates the tallyFixture delegations and validators fields.
+// WARNING: delegate must be called *after* any calls to govKeeper.DelegateToGovernor
+// because the hooks are not invoked in this test setup.
+func (s *fixture) delegate(delegator sdk.AccAddress, validator sdk.ValAddress, m int64) {
+	// Increment total bonded according to each delegations
+	s.totalBonded += m
+	delegation := stakingtypes.Delegation{
+		DelegatorAddress: delegator.String(),
+		ValidatorAddress: validator.String(),
+	}
+	// Increase validator shares and tokens, compute delegation.Shares
+	for i := 0; i < len(s.validators); i++ {
+		if s.validators[i].OperatorAddress == validator.String() {
+			s.validators[i], delegation.Shares = s.validators[i].AddTokensFromDel(sdk.NewInt(m))
+			break
+		}
+	}
+	s.delegations = append(s.delegations, delegation)
+}
+
+// vote calls govKeeper.Vote()
+func (s *fixture) vote(voter sdk.AccAddress, vote v1.VoteOption) {
+	err := s.keeper.AddVote(s.ctx, s.proposal.Id, voter, v1.NewNonSplitVoteOption(vote), "")
+	require.NoError(s.t, err)
+}
+
+func (s *fixture) validatorVote(voter sdk.ValAddress, vote v1.VoteOption) {
+	s.vote(sdk.AccAddress(voter), vote)
+}
+
+func (s *fixture) governorVote(voter types.GovernorAddress, vote v1.VoteOption) {
+	s.vote(sdk.AccAddress(voter), vote)
+}

--- a/x/gov/keeper/governor.go
+++ b/x/gov/keeper/governor.go
@@ -93,14 +93,14 @@ func (k Keeper) getGovernorBondedTokens(ctx sdk.Context, govAddr types.GovernorA
 }
 
 func (k Keeper) ValidateGovernorMinSelfDelegation(ctx sdk.Context, governor v1.Governor) bool {
-	minGovernorSelfDelegation, _ := math.NewIntFromString(k.GetParams(ctx).MinGovernorSelfDelegation)
-	bondedTokens := k.getGovernorBondedTokens(ctx, governor.GetAddress())
-	delAddr := sdk.AccAddress(governor.GetAddress())
-
 	// ensure that the governor is active and that has a valid governance self-delegation
 	if !governor.IsActive() {
 		return false
 	}
+	minGovernorSelfDelegation, _ := math.NewIntFromString(k.GetParams(ctx).MinGovernorSelfDelegation)
+	bondedTokens := k.getGovernorBondedTokens(ctx, governor.GetAddress())
+	delAddr := sdk.AccAddress(governor.GetAddress())
+
 	if del, found := k.GetGovernanceDelegation(ctx, delAddr); !found || !governor.GetAddress().Equals(types.MustGovernorAddressFromBech32(del.GovernorAddress)) {
 		panic("active governor without governance self-delegation")
 	}

--- a/x/gov/keeper/governor_test.go
+++ b/x/gov/keeper/governor_test.go
@@ -1,0 +1,83 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+
+	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
+)
+
+func TestGovernor(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	govKeeper, _, _, ctx := setupGovKeeper(t)
+	addrs := simtestutil.CreateRandomAccounts(3)
+	govAddrs := convertAddrsToGovAddrs(addrs)
+
+	// Add 2 governors
+	gov1Desc := v1.NewGovernorDescription("moniker1", "id1", "website1", "sec1", "detail1")
+	gov1, err := v1.NewGovernor(govAddrs[0].String(), gov1Desc, time.Now().UTC())
+	require.NoError(err)
+	gov2Desc := v1.NewGovernorDescription("moniker2", "id2", "website2", "sec2", "detail2")
+	gov2, err := v1.NewGovernor(govAddrs[1].String(), gov2Desc, time.Now().UTC())
+	gov2.Status = v1.Inactive
+	require.NoError(err)
+	govKeeper.SetGovernor(ctx, gov1)
+	govKeeper.SetGovernor(ctx, gov2)
+
+	// Get gov1
+	gov, found := govKeeper.GetGovernor(ctx, govAddrs[0])
+	if assert.True(found, "cant find gov1") {
+		assert.Equal(gov1, gov)
+	}
+
+	// Get gov2
+	gov, found = govKeeper.GetGovernor(ctx, govAddrs[1])
+	if assert.True(found, "cant find gov2") {
+		assert.Equal(gov2, gov)
+	}
+
+	// Get all govs
+	govs := govKeeper.GetAllGovernors(ctx)
+	if assert.Len(govs, 2, "expected 2 governors") {
+		// Insert order is not preserved, order is related to the address which is
+		// generated randomly, so the order of govs is random.
+		for i := 0; i < 2; i++ {
+			switch govs[i].GetAddress().String() {
+			case gov1.GetAddress().String():
+				assert.Equal(gov1, *govs[i])
+			case gov2.GetAddress().String():
+				assert.Equal(gov2, *govs[i])
+			}
+		}
+	}
+
+	// Get all active govs
+	govs = govKeeper.GetAllActiveGovernors(ctx)
+	if assert.Len(govs, 1, "expected 1 active governor") {
+		assert.Equal(gov1, *govs[0])
+	}
+
+	// IterateGovernors
+	govs = nil
+	govKeeper.IterateGovernors(ctx, func(i int64, govI v1.GovernorI) bool {
+		gov := govI.(v1.Governor)
+		govs = append(govs, &gov)
+		return false
+	})
+	if assert.Len(govs, 2, "expected 2 governors") {
+		for i := 0; i < 2; i++ {
+			switch govs[i].GetAddress().String() {
+			case gov1.GetAddress().String():
+				assert.Equal(gov1, *govs[i])
+			case gov2.GetAddress().String():
+				assert.Equal(gov2, *govs[i])
+			}
+		}
+	}
+}

--- a/x/gov/keeper/governor_test.go
+++ b/x/gov/keeper/governor_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
 )
@@ -79,5 +82,110 @@ func TestGovernor(t *testing.T) {
 				assert.Equal(gov2, *govs[i])
 			}
 		}
+	}
+}
+
+func TestValidateGovernorMinSelfDelegation(t *testing.T) {
+	var (
+		addrs = simtestutil.CreateRandomAccounts(2)
+		// TODO add multiple validator and delegations
+		valAddr   = simtestutil.ConvertAddrsToValAddrs(addrs[:1])[0]
+		validator = stakingtypes.Validator{
+			OperatorAddress: valAddr.String(),
+			Status:          stakingtypes.Bonded,
+			Tokens:          sdk.OneInt(),
+			DelegatorShares: sdk.OneDec(),
+		}
+		govAddr = convertAddrsToGovAddrs(addrs[1:])[0]
+	)
+	tests := []struct {
+		name           string
+		governor       v1.Governor
+		selfDelegation bool
+		valDelegations []stakingtypes.Delegation
+		expectedPanic  bool
+		expectedValid  bool
+	}{
+		{
+			name:           "inactive governor",
+			governor:       v1.Governor{GovernorAddress: govAddr.String(), Status: v1.Inactive},
+			selfDelegation: false,
+			valDelegations: nil,
+			expectedPanic:  false,
+			expectedValid:  false,
+		},
+		{
+			name:           "active governor w/o self delegation w/o validator delegation",
+			governor:       v1.Governor{GovernorAddress: govAddr.String(), Status: v1.Active},
+			selfDelegation: false,
+			valDelegations: nil,
+			expectedPanic:  true,
+			expectedValid:  false,
+		},
+		{
+			name:           "active governor w self delegation w/o validator delegation",
+			governor:       v1.Governor{GovernorAddress: govAddr.String(), Status: v1.Active},
+			selfDelegation: true,
+			valDelegations: nil,
+			expectedPanic:  false,
+			expectedValid:  false,
+		},
+		{
+			name:           "active governor w self delegation w not enough validator delegation",
+			governor:       v1.Governor{GovernorAddress: govAddr.String(), Status: v1.Active},
+			selfDelegation: true,
+			valDelegations: []stakingtypes.Delegation{
+				{
+					DelegatorAddress: govAddr.String(),
+					ValidatorAddress: valAddr.String(),
+					Shares:           sdk.OneDec(),
+				},
+			},
+			expectedPanic: false,
+			expectedValid: false,
+		},
+		{
+			name:           "active governor w self delegation w enough validator delegation",
+			governor:       v1.Governor{GovernorAddress: govAddr.String(), Status: v1.Active},
+			selfDelegation: true,
+			valDelegations: []stakingtypes.Delegation{
+				{
+					DelegatorAddress: govAddr.String(),
+					ValidatorAddress: valAddr.String(),
+					Shares:           v1.DefaultMinGovernorSelfDelegation.ToLegacyDec(),
+				},
+			},
+			expectedPanic: false,
+			expectedValid: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			govKeeper, mocks, _, ctx := setupGovKeeper(t, mockAccountKeeperExpectations)
+			// setup validator delegations expectation
+			mocks.stakingKeeper.EXPECT().GetValidator(ctx, valAddr).Return(validator, true).AnyTimes()
+			delAddr := sdk.AccAddress(govAddr)
+			mocks.stakingKeeper.EXPECT().IterateDelegations(ctx, delAddr, gomock.Any()).
+				DoAndReturn(
+					func(_ sdk.Context, _ sdk.AccAddress, f func(int64, stakingtypes.DelegationI) bool) {
+						for i, d := range tt.valDelegations {
+							if f(int64(i), d) {
+								return
+							}
+						}
+					},
+				).MaxTimes(2)
+			if tt.selfDelegation {
+				govKeeper.DelegateToGovernor(ctx, delAddr, govAddr)
+			}
+
+			if tt.expectedPanic {
+				assert.Panics(t, func() { govKeeper.ValidateGovernorMinSelfDelegation(ctx, tt.governor) })
+			} else {
+				valid := govKeeper.ValidateGovernorMinSelfDelegation(ctx, tt.governor)
+
+				assert.Equal(t, tt.expectedValid, valid, "return of ValidateGovernorMinSelfDelegation")
+			}
+		})
 	}
 }

--- a/x/gov/keeper/tally_test.go
+++ b/x/gov/keeper/tally_test.go
@@ -1,178 +1,21 @@
 package keeper_test
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	sdkmath "cosmossdk.io/math"
-
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/atomone-hub/atomone/x/gov/keeper"
 	"github.com/atomone-hub/atomone/x/gov/types"
 	v1 "github.com/atomone-hub/atomone/x/gov/types/v1"
 )
 
-type tallyFixture struct {
-	t *testing.T
-
-	proposal    v1.Proposal
-	valAddrs    []sdk.ValAddress
-	delAddrs    []sdk.AccAddress
-	govAddrs    []types.GovernorAddress
-	totalBonded int64
-	validators  []stakingtypes.Validator
-	delegations []stakingtypes.Delegation
-
-	keeper *keeper.Keeper
-	ctx    sdk.Context
-	mocks  mocks
-}
-
-// newTallyFixture returns a configured fixture for testing the govKeeper.Tally
-// method.
-// - setup TotalBondedTokens call
-// - initiates the validators with a self delegation of 1:
-//   - setup IterateBondedValidatorsByPower call
-//   - setup IterateDelegations call for validators
-func newTallyFixture(t *testing.T, ctx sdk.Context, proposal v1.Proposal,
-	valAddrs []sdk.ValAddress, delAddrs []sdk.AccAddress, govAddrs []types.GovernorAddress,
-	govKeeper *keeper.Keeper, mocks mocks,
-) *tallyFixture {
-	s := &tallyFixture{
-		t:        t,
-		ctx:      ctx,
-		proposal: proposal,
-		valAddrs: valAddrs,
-		delAddrs: delAddrs,
-		govAddrs: govAddrs,
-		keeper:   govKeeper,
-		mocks:    mocks,
-	}
-	mocks.stakingKeeper.EXPECT().TotalBondedTokens(gomock.Any()).
-		DoAndReturn(func(_ context.Context) sdkmath.Int {
-			return sdkmath.NewInt(s.totalBonded)
-		}).MaxTimes(1)
-
-	// Mocks a bunch of validators
-	for i := 0; i < len(valAddrs); i++ {
-		s.validators = append(s.validators, stakingtypes.Validator{
-			OperatorAddress: valAddrs[i].String(),
-			Status:          stakingtypes.Bonded,
-			Tokens:          sdkmath.ZeroInt(),
-			DelegatorShares: sdkmath.LegacyZeroDec(),
-		})
-		// validator self delegation
-		s.delegate(sdk.AccAddress(valAddrs[i]), valAddrs[i], 1)
-	}
-	mocks.stakingKeeper.EXPECT().
-		IterateBondedValidatorsByPower(ctx, gomock.Any()).
-		DoAndReturn(
-			func(ctx context.Context, fn func(index int64, validator stakingtypes.ValidatorI) bool) error {
-				for i := 0; i < len(valAddrs); i++ {
-					fn(int64(i), s.validators[i])
-				}
-				return nil
-			})
-	mocks.stakingKeeper.EXPECT().
-		IterateDelegations(ctx, gomock.Any(), gomock.Any()).
-		DoAndReturn(
-			func(ctx context.Context, voter sdk.AccAddress, fn func(index int64, d stakingtypes.DelegationI) bool) error {
-				for i, d := range s.delegations {
-					if d.DelegatorAddress == voter.String() {
-						fn(int64(i), d)
-					}
-				}
-				return nil
-			}).AnyTimes()
-	mocks.stakingKeeper.EXPECT().GetValidator(ctx, gomock.Any()).DoAndReturn(
-		func(ctx context.Context, addr sdk.ValAddress) (stakingtypes.ValidatorI, bool) {
-			for i := 0; i < len(valAddrs); i++ {
-				if valAddrs[i].String() == addr.String() {
-					return s.validators[i], true
-				}
-			}
-			return nil, false
-		}).AnyTimes()
-	mocks.stakingKeeper.EXPECT().GetDelegation(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, del sdk.AccAddress, val sdk.ValAddress) (stakingtypes.Delegation, bool) {
-			for _, d := range s.delegations {
-				if d.DelegatorAddress == del.String() && d.ValidatorAddress == val.String() {
-					return d, true
-				}
-			}
-			return stakingtypes.Delegation{}, false
-		}).AnyTimes()
-
-	// Create active governors
-	for i := 0; i < len(govAddrs)-1; i++ {
-		governor, err := v1.NewGovernor(govAddrs[i].String(), v1.GovernorDescription{}, time.Now())
-		require.NoError(t, err)
-		govKeeper.SetGovernor(ctx, governor)
-		// governor self delegation
-		accAddr := sdk.AccAddress(govAddrs[i])
-		s.delegate(accAddr, valAddrs[0], 1)
-		s.delegate(accAddr, valAddrs[1], 2)
-		govKeeper.DelegateToGovernor(ctx, accAddr, govAddrs[i])
-	}
-	// Create one inactive governor
-	inactiveGovAddr := govAddrs[len(govAddrs)-1]
-	governor, err := v1.NewGovernor(inactiveGovAddr.String(), v1.GovernorDescription{}, time.Now())
-	require.NoError(t, err)
-	governor.Status = v1.Inactive
-	govKeeper.SetGovernor(ctx, governor)
-	accAddr := sdk.AccAddress(inactiveGovAddr)
-	s.delegate(accAddr, valAddrs[0], 1)
-	s.delegate(accAddr, valAddrs[1], 2)
-	govKeeper.DelegateToGovernor(ctx, accAddr, inactiveGovAddr)
-	return s
-}
-
-// delegate updates the tallyFixture delegations and validators fields.
-// WARNING: delegate must be called *after* any calls to govKeeper.DelegateToGovernor
-// because the hooks are not invoked in this test setup.
-func (s *tallyFixture) delegate(delegator sdk.AccAddress, validator sdk.ValAddress, m int64) {
-	// Increment total bonded according to each delegations
-	s.totalBonded += m
-	delegation := stakingtypes.Delegation{
-		DelegatorAddress: delegator.String(),
-		ValidatorAddress: validator.String(),
-	}
-	// Increase validator shares and tokens, compute delegation.Shares
-	for i := 0; i < len(s.validators); i++ {
-		if s.validators[i].OperatorAddress == validator.String() {
-			s.validators[i], delegation.Shares = s.validators[i].AddTokensFromDel(sdk.NewInt(m))
-			break
-		}
-	}
-	s.delegations = append(s.delegations, delegation)
-}
-
-// vote calls govKeeper.Vote()
-func (s *tallyFixture) vote(voter sdk.AccAddress, vote v1.VoteOption) {
-	err := s.keeper.AddVote(s.ctx, s.proposal.Id, voter, v1.NewNonSplitVoteOption(vote), "")
-	require.NoError(s.t, err)
-}
-
-func (s *tallyFixture) validatorVote(voter sdk.ValAddress, vote v1.VoteOption) {
-	s.vote(sdk.AccAddress(voter), vote)
-}
-
-func (s *tallyFixture) governorVote(voter types.GovernorAddress, vote v1.VoteOption) {
-	s.vote(sdk.AccAddress(voter), vote)
-}
-
 func TestTally(t *testing.T) {
 	tests := []struct {
 		name          string
-		setup         func(*tallyFixture)
+		setup         func(*fixture)
 		proposalMsgs  []sdk.Msg
 		expectedPass  bool
 		expectedBurn  bool
@@ -192,7 +35,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one validator votes: prop fails/burn deposit",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_NO)
 			},
 			proposalMsgs: TestProposal,
@@ -206,7 +49,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one account votes without delegation: prop fails/burn deposit",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.vote(s.delAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 			},
 			proposalMsgs: TestProposal,
@@ -220,7 +63,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one delegator votes: prop fails/burn deposit",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.vote(s.delAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 			},
@@ -235,7 +78,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one governor vote w/o delegation: prop fails/burn deposit",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// gov0 VP=3 vote=yes
 				s.governorVote(s.govAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 			},
@@ -250,7 +93,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one governor vote inherits delegation that didn't vote",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// del0 VP=5 del=gov0 didn't vote
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.delegate(s.delAddrs[0], s.valAddrs[1], 3)
@@ -269,7 +112,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "inactive governor vote doesn't inherit delegation that didn't vote",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// del0 VP=5 del=gov2(inactive) didn't vote
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.delegate(s.delAddrs[0], s.valAddrs[1], 3)
@@ -288,7 +131,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one governor votes yes, one delegator votes yes",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// del0 VP=5 del=gov0 vote=yes
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.delegate(s.delAddrs[0], s.valAddrs[1], 3)
@@ -308,7 +151,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one governor votes yes, one delegator votes no",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// del0 VP=5 del=gov0 vote=no
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.delegate(s.delAddrs[0], s.valAddrs[1], 3)
@@ -329,7 +172,7 @@ func TestTally(t *testing.T) {
 		{
 			// Same case as previous one but with reverted vote order
 			name: "one delegator votes no, one governor votes yes",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// gov0 VP=3 del=gov0 vote=yes
 				s.governorVote(s.govAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				// del0 VP=5 vote=no
@@ -349,7 +192,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one governor votes and some delegations vote",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// del0 VP=2 del=gov0 vote=no
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.keeper.DelegateToGovernor(s.ctx, s.delAddrs[0], s.govAddrs[0])
@@ -387,7 +230,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "two governors vote and some delegations vote",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				// del0 VP=2 del=gov0 vote=no
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.keeper.DelegateToGovernor(s.ctx, s.delAddrs[0], s.govAddrs[0])
@@ -427,7 +270,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one delegator votes yes, validator votes also yes: prop fails/burn deposit",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 1)
 				s.vote(s.delAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
@@ -443,7 +286,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "one delegator votes yes, validator votes no: prop fails/burn deposit",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 1)
 				s.vote(s.delAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_NO)
@@ -459,7 +302,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "validator votes yes, doesn't inherit delegations",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.delegate(s.delAddrs[1], s.valAddrs[0], 2)
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_NO)
@@ -480,7 +323,7 @@ func TestTally(t *testing.T) {
 			// second validator votes no
 			// third validator (no delegation) votes abstain
 			name: "delegator with mixed delegations: prop pass",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 2)
 				s.delegate(s.delAddrs[0], s.valAddrs[1], 2)
 				s.vote(s.delAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
@@ -499,7 +342,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "quorum reached with only abstain: prop fails",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_ABSTAIN)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_ABSTAIN)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_ABSTAIN)
@@ -517,7 +360,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "quorum reached with yes<=.667: prop fails",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
@@ -535,7 +378,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "quorum reached with yes>.667: prop succeeds",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_YES)
@@ -554,7 +397,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "quorum reached thanks to abstain, yes>.667: prop succeeds",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
@@ -573,7 +416,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "amendment quorum not reached: prop fails",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 			},
@@ -588,7 +431,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "amendment quorum reached and threshold not reached: prop fails",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
@@ -607,7 +450,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "amendment quorum reached and threshold reached: prop passes",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
@@ -631,7 +474,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "law quorum not reached: prop fails",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
 			},
@@ -646,7 +489,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "law quorum reached and threshold not reached: prop fails",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
@@ -665,7 +508,7 @@ func TestTally(t *testing.T) {
 		},
 		{
 			name: "law quorum reached and threshold reached: prop passes",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_YES)
@@ -691,21 +534,20 @@ func TestTally(t *testing.T) {
 			params.MinGovernorSelfDelegation = "1"
 			err := govKeeper.SetParams(ctx, params)
 			require.NoError(t, err)
-			var (
-				numVals       = 10
-				numDelegators = 6
-				numGovernors  = 3
-				addrs         = simtestutil.CreateRandomAccounts(numVals + numDelegators + numGovernors)
-				valAddrs      = simtestutil.ConvertAddrsToValAddrs(addrs[:numVals])
-				delAddrs      = addrs[numVals : numVals+numDelegators]
-				govAddrs      = convertAddrsToGovAddrs(addrs[numVals+numDelegators:])
-			)
+			// Create the test fixture
+			s := newFixture(t, ctx, 10, 6, 3, govKeeper, mocks)
+			// Setup governor self delegation
+			for _, govAddr := range s.govAddrs {
+				accAddr := sdk.AccAddress(govAddr)
+				s.delegate(accAddr, s.valAddrs[0], 1)
+				s.delegate(accAddr, s.valAddrs[1], 2)
+				govKeeper.DelegateToGovernor(ctx, accAddr, govAddr)
+			}
 			// Submit and activate a proposal
-			proposal, err := govKeeper.SubmitProposal(ctx, tt.proposalMsgs, "", "title", "summary", delAddrs[0])
+			proposal, err := govKeeper.SubmitProposal(ctx, tt.proposalMsgs, "", "title", "summary", s.delAddrs[0])
 			require.NoError(t, err)
 			govKeeper.ActivateVotingPeriod(ctx, proposal)
-			// Create the test fixture
-			s := newTallyFixture(t, ctx, proposal, valAddrs, delAddrs, govAddrs, govKeeper, mocks)
+			s.proposal = proposal
 			if tt.setup != nil {
 				tt.setup(s)
 			}
@@ -724,20 +566,20 @@ func TestHasReachedQuorum(t *testing.T) {
 	tests := []struct {
 		name           string
 		proposalMsgs   []sdk.Msg
-		setup          func(*tallyFixture)
+		setup          func(*fixture)
 		expectedQuorum bool
 	}{
 		{
 			name:         "no votes: no quorum",
 			proposalMsgs: TestProposal,
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 			},
 			expectedQuorum: false,
 		},
 		{
 			name:         "not enough votes: no quorum",
 			proposalMsgs: TestProposal,
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_NO)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 			},
@@ -746,7 +588,7 @@ func TestHasReachedQuorum(t *testing.T) {
 		{
 			name:         "enough votes: quorum",
 			proposalMsgs: TestProposal,
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_NO)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.delegate(s.delAddrs[0], s.valAddrs[2], 500000)
@@ -760,7 +602,7 @@ func TestHasReachedQuorum(t *testing.T) {
 		{
 			name:         "quorum reached by governor vote inheritance",
 			proposalMsgs: TestProposal,
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.delegate(s.delAddrs[0], s.valAddrs[0], 500000)
 				s.keeper.DelegateToGovernor(s.ctx, s.delAddrs[0], s.govAddrs[0])
 				s.governorVote(s.govAddrs[0], v1.VoteOption_VOTE_OPTION_ABSTAIN)
@@ -769,7 +611,7 @@ func TestHasReachedQuorum(t *testing.T) {
 		},
 		{
 			name: "amendment quorum not reached",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 			},
@@ -778,7 +620,7 @@ func TestHasReachedQuorum(t *testing.T) {
 		},
 		{
 			name: "amendment quorum reached",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
@@ -796,7 +638,7 @@ func TestHasReachedQuorum(t *testing.T) {
 		},
 		{
 			name: "law quorum not reached",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_NO)
 			},
@@ -805,7 +647,7 @@ func TestHasReachedQuorum(t *testing.T) {
 		},
 		{
 			name: "law quorum reached",
-			setup: func(s *tallyFixture) {
+			setup: func(s *fixture) {
 				s.validatorVote(s.valAddrs[0], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[1], v1.VoteOption_VOTE_OPTION_YES)
 				s.validatorVote(s.valAddrs[2], v1.VoteOption_VOTE_OPTION_YES)
@@ -823,21 +665,20 @@ func TestHasReachedQuorum(t *testing.T) {
 			params.MinGovernorSelfDelegation = "1"
 			err := govKeeper.SetParams(ctx, params)
 			require.NoError(t, err)
-			var (
-				numVals       = 10
-				numDelegators = 5
-				numGovernors  = 3
-				addrs         = simtestutil.CreateRandomAccounts(numVals + numDelegators + numGovernors)
-				valAddrs      = simtestutil.ConvertAddrsToValAddrs(addrs[:numVals])
-				delAddrs      = addrs[numVals : numVals+numDelegators]
-				govAddrs      = convertAddrsToGovAddrs(addrs[numVals+numDelegators:])
-			)
 			// Submit and activate a proposal
-			proposal, err := govKeeper.SubmitProposal(ctx, tt.proposalMsgs, "", "title", "summary", delAddrs[0])
+			s := newFixture(t, ctx, 10, 5, 3, govKeeper, mocks)
+			// Setup governor self delegation
+			for _, govAddr := range s.govAddrs {
+				accAddr := sdk.AccAddress(govAddr)
+				s.delegate(accAddr, s.valAddrs[0], 1)
+				s.delegate(accAddr, s.valAddrs[1], 2)
+				govKeeper.DelegateToGovernor(ctx, accAddr, govAddr)
+			}
+			proposal, err := govKeeper.SubmitProposal(ctx, tt.proposalMsgs, "", "title", "summary", s.delAddrs[0])
 			require.NoError(t, err)
+			s.proposal = proposal
 			govKeeper.ActivateVotingPeriod(ctx, proposal)
-			suite := newTallyFixture(t, ctx, proposal, valAddrs, delAddrs, govAddrs, govKeeper, mocks)
-			tt.setup(suite)
+			tt.setup(s)
 
 			quorum, err := govKeeper.HasReachedQuorum(ctx, proposal)
 
@@ -845,7 +686,7 @@ func TestHasReachedQuorum(t *testing.T) {
 			assert.Equal(t, tt.expectedQuorum, quorum)
 			if tt.expectedQuorum {
 				// Assert votes are still here after HasReachedQuorum
-				votes := suite.keeper.GetVotes(suite.ctx, proposal.Id)
+				votes := s.keeper.GetVotes(s.ctx, proposal.Id)
 				assert.NotEmpty(t, votes, "votes must be kept after HasReachedQuorum")
 			}
 		})

--- a/x/gov/simulation/genesis.go
+++ b/x/gov/simulation/genesis.go
@@ -186,8 +186,6 @@ func RandomizedGenState(simState *module.SimulationState) {
 	var quorumCheckCount uint64
 	simState.AppParams.GetOrGenerate(simState.Cdc, QuorumCheckCount, &quorumCheckCount, simState.Rand, func(r *rand.Rand) { quorumCheckCount = GenQuorumCheckCount(r) })
 
-	maxGovernors := uint64(simState.Rand.Intn(100))
-
 	var governorStatusChangePeriod time.Duration
 	simState.AppParams.GetOrGenerate(
 		simState.Cdc, GovernorStatusChangePeriod, &governorStatusChangePeriod, simState.Rand,
@@ -202,7 +200,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 
 	govGenesis := v1.NewGenesisState(
 		startingProposalID,
-		v1.NewParams(minDeposit, depositPeriod, votingPeriod, quorum.String(), threshold.String(), amendmentsQuorum.String(), amendmentsThreshold.String(), lawQuorum.String(), lawThreshold.String(), minInitialDepositRatio.String(), simState.Rand.Intn(2) == 0, simState.Rand.Intn(2) == 0, minDepositRatio.String(), quorumTimout, maxVotingPeriodExtension, quorumCheckCount, maxGovernors, governorStatusChangePeriod, minGovernorSelfDelegation.String()),
+		v1.NewParams(minDeposit, depositPeriod, votingPeriod, quorum.String(), threshold.String(), amendmentsQuorum.String(), amendmentsThreshold.String(), lawQuorum.String(), lawThreshold.String(), minInitialDepositRatio.String(), simState.Rand.Intn(2) == 0, simState.Rand.Intn(2) == 0, minDepositRatio.String(), quorumTimout, maxVotingPeriodExtension, quorumCheckCount, governorStatusChangePeriod, minGovernorSelfDelegation.String()),
 	)
 
 	bz, err := json.MarshalIndent(&govGenesis, "", " ")

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -68,7 +68,7 @@ func NewParams(
 	quorum, threshold, constitutionAmendmentQuorum, constitutionAmendmentThreshold, lawQuorum, lawThreshold, minInitialDepositRatio string,
 	burnProposalDeposit, burnVoteQuorum bool, minDepositRatio string,
 	quorumTimeout, maxVotingPeriodExtension time.Duration, quorumCheckCount uint64,
-	maxGovernors uint64, governorStatusChangePeriod time.Duration, minGovernorSelfDelegation string,
+	maxGovernors uint64 /*TODO remove maxGovernors? */, governorStatusChangePeriod time.Duration, minGovernorSelfDelegation string,
 ) Params {
 	return Params{
 		MinDeposit:                     minDeposit,

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -68,7 +68,7 @@ func NewParams(
 	quorum, threshold, constitutionAmendmentQuorum, constitutionAmendmentThreshold, lawQuorum, lawThreshold, minInitialDepositRatio string,
 	burnProposalDeposit, burnVoteQuorum bool, minDepositRatio string,
 	quorumTimeout, maxVotingPeriodExtension time.Duration, quorumCheckCount uint64,
-	maxGovernors uint64 /*TODO remove maxGovernors? */, governorStatusChangePeriod time.Duration, minGovernorSelfDelegation string,
+	governorStatusChangePeriod time.Duration, minGovernorSelfDelegation string,
 ) Params {
 	return Params{
 		MinDeposit:                     minDeposit,
@@ -111,7 +111,6 @@ func DefaultParams() Params {
 		DefaultQuorumTimeout,
 		DefaultMaxVotingPeriodExtension,
 		DefaultQuorumCheckCount,
-		DefaultMaxGovernors,
 		DefaultGovernorStatusChangePeriod,
 		DefaultMinGovernorSelfDelegation.String(),
 	)


### PR DESCRIPTION
Add tests on Governor creation, delegation and validator shares. 
Moved `tallyFixture` into a more generic `fixture` type so it can be reused in other tests that requires validator delegations.