### PR TITLE
test(x/gov): add e2e tests for governors

### DIFF
--- a/tests/e2e/e2e_rest_regression_test.go
+++ b/tests/e2e/e2e_rest_regression_test.go
@@ -37,7 +37,7 @@ const (
 	authParamsModuleQueryPath           = "/cosmos/auth/v1beta1/params"
 	distributionCommPoolModuleQueryPath = "/cosmos/distribution/v1beta1/community_pool"
 	evidenceModuleQueryPath             = "/cosmos/evidence/v1beta1/evidence"
-	govPropsModuleQueryPath             = "/atomone/gov/v1beta1/proposals"
+	govPropsModuleQueryPath             = "/atomone/gov/v1/proposals"
 	mintParamsModuleQueryPath           = "/cosmos/mint/v1beta1/params"
 	slashingParamsModuleQueryPath       = "/cosmos/slashing/v1beta1/params"
 	stakingParamsModuleQueryPath        = "/cosmos/staking/v1beta1/params"

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -65,6 +65,7 @@ const (
 	proposalMaxTotalBypassFilename        = "proposal_max_total_bypass.json"
 	proposalCommunitySpendFilename        = "proposal_community_spend.json"
 	proposalParamChangeFilename           = "param_change.json"
+	proposalTextFilename                  = "text.json"
 	proposalConstitutionAmendmentFilename = "constitution_amendment.json"
 	newConstitutionFilename               = "new_constitution.md"
 

--- a/tests/e2e/e2e_staking_test.go
+++ b/tests/e2e/e2e_staking_test.go
@@ -25,30 +25,11 @@ func (s *IntegrationTestSuite) testStaking() {
 
 		delegatorAddress, _ := s.chainA.genesisAccounts[2].keyInfo.GetAddress()
 
-		existingDelegation := sdk.ZeroDec()
-		res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-		if err == nil {
-			existingDelegation = res.GetDelegationResponse().GetDelegation().GetShares()
-		}
-
 		delegationAmount := sdk.NewInt(500000000)
 		delegation := sdk.NewCoin(uatoneDenom, delegationAmount) // 500 atom
 
 		// Alice delegate uatone to Validator A
-		s.execDelegate(s.chainA, 0, delegation.String(), validatorAddressA, delegatorAddress.String(), atomoneHomePath)
-
-		// Validate delegation successful
-		s.Require().Eventually(
-			func() bool {
-				res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-				amt := res.GetDelegationResponse().GetDelegation().GetShares()
-				s.Require().NoError(err)
-
-				return amt.Equal(existingDelegation.Add(sdk.NewDecFromInt(delegationAmount)))
-			},
-			20*time.Second,
-			time.Second,
-		)
+		s.execDelegate(s.chainA, 0, delegation, validatorAddressA, delegatorAddress.String())
 
 		redelegationAmount := delegationAmount.Quo(sdk.NewInt(2))
 		redelegation := sdk.NewCoin(uatoneDenom, redelegationAmount) // 250 atom
@@ -59,9 +40,9 @@ func (s *IntegrationTestSuite) testStaking() {
 		// Validate re-delegation successful
 		s.Require().Eventually(
 			func() bool {
-				res, err := queryDelegation(chainEndpoint, validatorAddressB, delegatorAddress.String())
-				amt := res.GetDelegationResponse().GetDelegation().GetShares()
+				res, err := s.queryDelegation(validatorAddressB, delegatorAddress.String())
 				s.Require().NoError(err)
+				amt := res.GetDelegationResponse().GetDelegation().GetShares()
 
 				return amt.Equal(sdk.NewDecFromInt(redelegationAmount))
 			},
@@ -77,9 +58,9 @@ func (s *IntegrationTestSuite) testStaking() {
 		// query alice's current delegation from validator A
 		s.Require().Eventually(
 			func() bool {
-				res, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-				amt := res.GetDelegationResponse().GetDelegation().GetShares()
+				res, err := s.queryDelegation(validatorAddressA, delegatorAddress.String())
 				s.Require().NoError(err)
+				amt := res.GetDelegationResponse().GetDelegation().GetShares()
 
 				currDelegationAmount = amt.TruncateInt()
 				currDelegation = sdk.NewCoin(uatoneDenom, currDelegationAmount)
@@ -124,9 +105,9 @@ func (s *IntegrationTestSuite) testStaking() {
 		// validate that unbonding delegation was successfully canceled
 		s.Require().Eventually(
 			func() bool {
-				resDel, err := queryDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())
-				amt := resDel.GetDelegationResponse().GetDelegation().GetShares()
+				resDel, err := s.queryDelegation(validatorAddressA, delegatorAddress.String())
 				s.Require().NoError(err)
+				amt := resDel.GetDelegationResponse().GetDelegation().GetShares()
 
 				// expect that no unbonding delegations are found for validator A
 				_, err = queryUnbondingDelegation(chainEndpoint, validatorAddressA, delegatorAddress.String())

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -61,6 +61,7 @@ func (s *IntegrationTestSuite) TestGov() {
 	s.testGovCommunityPoolSpend()
 	s.testGovParamChange()
 	s.testGovConstitutionAmendment()
+	s.testGovGovernors()
 }
 
 func (s *IntegrationTestSuite) TestIBC() {

--- a/tests/e2e/e2e_vesting_test.go
+++ b/tests/e2e/e2e_vesting_test.go
@@ -61,21 +61,7 @@ func (s *IntegrationTestSuite) testDelayedVestingAccount(api string) {
 		s.Require().Equal(vestingBalance.AmountOf(uatoneDenom), balance.Amount)
 
 		// Delegate coins should succeed
-		s.execDelegate(chain, valIdx, vestingDelegationAmount.String(), valOpAddr,
-			vestingDelayedAcc.String(), atomoneHomePath)
-
-		// Validate delegation successful
-		s.Require().Eventually(
-			func() bool {
-				res, err := queryDelegation(api, valOpAddr, vestingDelayedAcc.String())
-				amt := res.GetDelegationResponse().GetDelegation().GetShares()
-				s.Require().NoError(err)
-
-				return amt.Equal(sdk.NewDecFromInt(vestingDelegationAmount.Amount))
-			},
-			20*time.Second,
-			time.Second,
-		)
+		s.execDelegate(chain, valIdx, vestingDelegationAmount, valOpAddr, vestingDelayedAcc.String())
 
 		waitTime := acc.EndTime - time.Now().Unix()
 		if waitTime > vestingTxDelay {
@@ -128,21 +114,7 @@ func (s *IntegrationTestSuite) testContinuousVestingAccount(api string) {
 		s.Require().Equal(vestingBalance.AmountOf(uatoneDenom), balance.Amount)
 
 		// Delegate coins should succeed
-		s.execDelegate(chain, valIdx, vestingDelegationAmount.String(),
-			valOpAddr, continuousVestingAcc.String(), atomoneHomePath)
-
-		// Validate delegation successful
-		s.Require().Eventually(
-			func() bool {
-				res, err := queryDelegation(api, valOpAddr, continuousVestingAcc.String())
-				amt := res.GetDelegationResponse().GetDelegation().GetShares()
-				s.Require().NoError(err)
-
-				return amt.Equal(sdk.NewDecFromInt(vestingDelegationAmount.Amount))
-			},
-			20*time.Second,
-			time.Second,
-		)
+		s.execDelegate(chain, valIdx, vestingDelegationAmount, valOpAddr, continuousVestingAcc.String())
 
 		waitStartTime := acc.StartTime - time.Now().Unix()
 		if waitStartTime > vestingTxDelay {
@@ -262,21 +234,7 @@ func (s *IntegrationTestSuite) testPeriodicVestingAccount(api string) { //nolint
 		}
 
 		// Delegate coins should succeed
-		s.execDelegate(chain, valIdx, vestingDelegationAmount.String(), valOpAddr,
-			periodicVestingAddr, atomoneHomePath)
-
-		// Validate delegation successful
-		s.Require().Eventually(
-			func() bool {
-				res, err := queryDelegation(api, valOpAddr, periodicVestingAddr)
-				amt := res.GetDelegationResponse().GetDelegation().GetShares()
-				s.Require().NoError(err)
-
-				return amt.Equal(sdk.NewDecFromInt(vestingDelegationAmount.Amount))
-			},
-			20*time.Second,
-			time.Second,
-		)
+		s.execDelegate(chain, valIdx, vestingDelegationAmount, valOpAddr, periodicVestingAddr)
 
 		//	Transfer coins should succeed
 		balance, err = getSpecificBalance(api, periodicVestingAddr, uatoneDenom)

--- a/tests/e2e/query_test.go
+++ b/tests/e2e/query_test.go
@@ -18,7 +18,6 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	govtypesv1 "github.com/atomone-hub/atomone/x/gov/types/v1"
-	govtypesv1beta1 "github.com/atomone-hub/atomone/x/gov/types/v1beta1"
 	photontypes "github.com/atomone-hub/atomone/x/photon/types"
 )
 
@@ -105,15 +104,14 @@ func queryStakingParams(endpoint string) (stakingtypes.QueryParamsResponse, erro
 	return params, nil
 }
 
-func queryDelegation(endpoint string, validatorAddr string, delegatorAddr string) (stakingtypes.QueryDelegationResponse, error) {
+func (s *IntegrationTestSuite) queryDelegation(validatorAddr string, delegatorAddr string) (stakingtypes.QueryDelegationResponse, error) {
 	var res stakingtypes.QueryDelegationResponse
-
+	endpoint := fmt.Sprintf("http://%s", s.valResources[s.chainA.id][0].GetHostPort("1317/tcp"))
 	body, err := httpGet(fmt.Sprintf("%s/cosmos/staking/v1beta1/validators/%s/delegations/%s", endpoint, validatorAddr, delegatorAddr))
 	if err != nil {
 		return res, err
 	}
-
-	if err = cdc.UnmarshalJSON(body, &res); err != nil {
+	if err := cdc.UnmarshalJSON(body, &res); err != nil {
 		return res, err
 	}
 	return res, nil
@@ -161,10 +159,10 @@ func queryDelegatorTotalRewards(endpoint, delegatorAddr string) (disttypes.Query
 	return res, nil
 }
 
-func queryGovProposal(endpoint string, proposalID int) (govtypesv1beta1.QueryProposalResponse, error) {
-	var govProposalResp govtypesv1beta1.QueryProposalResponse
+func queryGovProposal(endpoint string, proposalID int) (govtypesv1.QueryProposalResponse, error) {
+	var govProposalResp govtypesv1.QueryProposalResponse
 
-	path := fmt.Sprintf("%s/atomone/gov/v1beta1/proposals/%d", endpoint, proposalID)
+	path := fmt.Sprintf("%s/atomone/gov/v1/proposals/%d", endpoint, proposalID)
 
 	body, err := httpGet(path)
 	if err != nil {
@@ -175,6 +173,54 @@ func queryGovProposal(endpoint string, proposalID int) (govtypesv1beta1.QueryPro
 	}
 
 	return govProposalResp, nil
+}
+
+func queryGovGovernor(endpoint string, govAddr string) (govtypesv1.QueryGovernorResponse, error) {
+	var resp govtypesv1.QueryGovernorResponse
+
+	path := fmt.Sprintf("%s/atomone/gov/v1/governor/%s", endpoint, govAddr)
+
+	body, err := httpGet(path)
+	if err != nil {
+		return resp, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	if err := cdc.UnmarshalJSON(body, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+func queryGovGovernorDelegation(endpoint string, delAddr string) (govtypesv1.QueryGovernanceDelegationResponse, error) {
+	var resp govtypesv1.QueryGovernanceDelegationResponse
+
+	path := fmt.Sprintf("%s/atomone/gov/v1/delegations/%s", endpoint, delAddr)
+
+	body, err := httpGet(path)
+	if err != nil {
+		return resp, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	if err := cdc.UnmarshalJSON(body, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+func queryGovGovernorValShares(endpoint string, govAddr string) (govtypesv1.QueryGovernorValSharesResponse, error) {
+	var resp govtypesv1.QueryGovernorValSharesResponse
+
+	path := fmt.Sprintf("%s/atomone/gov/v1/vshares/%s", endpoint, govAddr)
+
+	body, err := httpGet(path)
+	if err != nil {
+		return resp, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	if err := cdc.UnmarshalJSON(body, &resp); err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }
 
 func queryAccount(endpoint, address string) (acc authtypes.AccountI, err error) {


### PR DESCRIPTION
Mainly adds the `testGovGovernor()` function, with some minor refactoring of the e2e code.

Had to switch the proposal request URL from `v1beta1` to `v1` because the later does not work with pure v1 text proposal (proposal without `sdk.Msg[]` and only metadata), which is the kind of proposal I wanted to test for governors.